### PR TITLE
Allow appender to accept byte[]

### DIFF
--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -1169,6 +1169,16 @@ void _duckdb_jdbc_appender_append_string(JNIEnv *env, jclass, jobject appender_r
 	get_appender(env, appender_ref_buf)->Append(string_value.c_str());
 }
 
+void _duckdb_jdbc_appender_append_bytes(JNIEnv *env, jclass, jobject appender_ref_buf, jbyteArray value) {
+	if (env->IsSameObject(value, NULL)) {
+		get_appender(env, appender_ref_buf)->Append<std::nullptr_t>(nullptr);
+		return;
+	}
+
+	auto string_value = byte_array_to_string(env, value);
+	get_appender(env, appender_ref_buf)->Append(Value::BLOB_RAW(string_value));
+}
+
 void _duckdb_jdbc_appender_append_null(JNIEnv *env, jclass, jobject appender_ref_buf) {
 	get_appender(env, appender_ref_buf)->Append<std::nullptr_t>(nullptr);
 }

--- a/src/jni/functions.cpp
+++ b/src/jni/functions.cpp
@@ -347,6 +347,16 @@ JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1appe
 	}
 }
 
+JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1bytes(JNIEnv * env, jclass param0, jobject param1, jbyteArray param2) {
+	try {
+		return _duckdb_jdbc_appender_append_bytes(env, param0, param1, param2);
+	} catch (const std::exception &e) {
+		duckdb::ErrorData error(e);
+		ThrowJNI(env, error.Message().c_str());
+
+	}
+}
+
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1timestamp(JNIEnv * env, jclass param0, jobject param1, jlong param2) {
 	try {
 		return _duckdb_jdbc_appender_append_timestamp(env, param0, param1, param2);

--- a/src/jni/functions.hpp
+++ b/src/jni/functions.hpp
@@ -141,6 +141,10 @@ void _duckdb_jdbc_appender_append_string(JNIEnv * env, jclass param0, jobject pa
 
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1string(JNIEnv * env, jclass param0, jobject param1, jbyteArray param2);
 
+void _duckdb_jdbc_appender_append_bytes(JNIEnv * env, jclass param0, jobject param1, jbyteArray param2);
+
+JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1bytes(JNIEnv * env, jclass param0, jobject param1, jbyteArray param2);
+
 void _duckdb_jdbc_appender_append_timestamp(JNIEnv * env, jclass param0, jobject param1, jlong param2);
 
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1timestamp(JNIEnv * env, jclass param0, jobject param1, jlong param2);

--- a/src/main/java/org/duckdb/DuckDBAppender.java
+++ b/src/main/java/org/duckdb/DuckDBAppender.java
@@ -85,6 +85,14 @@ public class DuckDBAppender implements AutoCloseable {
         }
     }
 
+    public void append(byte[] value) throws SQLException {
+        if (value == null) {
+            DuckDBNative.duckdb_jdbc_appender_append_null(appender_ref);
+        } else {
+            DuckDBNative.duckdb_jdbc_appender_append_bytes(appender_ref, value);
+        }
+    }
+
     protected void finalize() throws Throwable {
         close();
     }

--- a/src/main/java/org/duckdb/DuckDBNative.java
+++ b/src/main/java/org/duckdb/DuckDBNative.java
@@ -154,6 +154,9 @@ class DuckDBNative {
     protected static native void duckdb_jdbc_appender_append_string(ByteBuffer appender_ref, byte[] value)
         throws SQLException;
 
+    protected static native void duckdb_jdbc_appender_append_bytes(ByteBuffer appender_ref, byte[] value)
+        throws SQLException;
+
     protected static native void duckdb_jdbc_appender_append_timestamp(ByteBuffer appender_ref, long value)
         throws SQLException;
 


### PR DESCRIPTION
Greetings!

We're writing a large amount of binary data and wanted to (for performance) eliminate a copy/serialization step that took our Java `byte[]` and made them in to a hex code escaped string. To achieve this with the JDBC driver, we:

- Added a `DuckDBAppender#append` method that accepts `byte[]`
- Made the corresponding JNI call treat the value as `BLOB_RAW`
  - In Java: without `getBytes` and an encoding
  - In CXX: without going from std::string -> cstr
- Added a test to ensure `byte[]` can be round-tripped losslessly.

To better illustrate the issue, a modified version of this test fails on trunk (using a [deprecated String constructor](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#String-byte:A-int-) that AFAICT does not apply any encoding) :

```java
    public static void test_appender_roundtrip_blob() throws Exception {
        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
        Statement stmt = conn.createStatement();

        stmt.execute("CREATE TABLE data (a BLOB)");

        DuckDBAppender appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "data");
        SecureRandom random = SecureRandom.getInstanceStrong();
        byte[] data = new byte[512];
        random.nextBytes(data);

        appender.beginRow();
        // This does not apply a charset encoding
        appender.append(new String(data, 0));
        appender.endRow();
        appender.flush();
        appender.close();

        ResultSet results = stmt.executeQuery("SELECT * FROM data");
        assertTrue(results.next());

        byte[] resultBlob = results.getBlob(1).getBinaryStream().readAllBytes();
        assertTrue(Arrays.equals(resultBlob, data), "byte[] data is round tripped untouched");

        results.close();
        stmt.close();
        conn.close();
    }
```

```
TestDuckDBJDBC#test_appender_roundtrip_blob failed with java.sql.SQLException: Invalid Input Error: Failed to cast value: Invalid byte encountered in STRING örÇoÀùuãÅUïÏ¾1è
java.sql.SQLException: Invalid Input Error: Failed to cast value: Invalid byte encountered in STRING -> BLOB conversion of string "#íiæþb­ð}´éA¡a
 þ;·p°g ,Çüó[,@Ä9hMÑú×zÇ       ý2?)8Lâ¦PôÞIõ!»C\         Y". All non-ascii characters must be escaped with hex codes (e.g. \xAA)
        at org.duckdb.DuckDBNative.duckdb_jdbc_appender_append_string(Native Method)
        at org.duckdb.DuckDBAppender.append(DuckDBAppender.java:84)
        at org.duckdb.TestDuckDBJDBC.test_appender_roundtrip_blob(TestDuckDBJDBC.java:2775)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.duckdb.test.Runner.runTests(Runner.java:45)
        at org.duckdb.TestDuckDBJDBC.main(TestDuckDBJDBC.java:4637)
```